### PR TITLE
Match tracking versions

### DIFF
--- a/artlib/common/BaseART.py
+++ b/artlib/common/BaseART.py
@@ -429,7 +429,12 @@ class BaseART(BaseEstimator, ClusterMixin):
             Permits external factors to influence cluster creation.
             Returns True if the cluster is valid for the sample, False otherwise
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         self.validate_data(X)
@@ -457,7 +462,12 @@ class BaseART(BaseEstimator, ClusterMixin):
         - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
             Permits external factors to influence cluster creation.
             Returns True if the cluster is valid for the sample, False otherwise
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
 

--- a/artlib/common/BaseART.py
+++ b/artlib/common/BaseART.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Optional, Callable, Iterable, Literal, List
+from typing import Optional, Callable, Iterable, Literal, List, Tuple
 from copy import deepcopy
 from collections import defaultdict
 from matplotlib.axes import Axes
@@ -7,6 +7,7 @@ from warnings import warn
 from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.utils.validation import check_is_fitted
 from artlib.common.utils import normalize, de_normalize
+import operator
 
 
 class BaseART(BaseEstimator, ClusterMixin):
@@ -198,7 +199,7 @@ class BaseART(BaseEstimator, ClusterMixin):
         """
         raise NotImplementedError
 
-    def match_criterion_bin(self, i: np.ndarray, w: np.ndarray, params: dict, cache: Optional[dict] = None) -> tuple[bool, dict]:
+    def match_criterion_bin(self, i: np.ndarray, w: np.ndarray, params: dict, cache: Optional[dict] = None, op: Callable = operator.ge) -> tuple[bool, dict]:
         """
         get the binary match criterion of the cluster
 
@@ -213,7 +214,7 @@ class BaseART(BaseEstimator, ClusterMixin):
 
         """
         M, cache = self.match_criterion(i, w, params=params, cache=cache)
-        M_bin = M > params["rho"]
+        M_bin = op(M, params["rho"])
         if cache is None:
             cache = dict()
         cache["match_criterion"] = M
@@ -274,8 +275,42 @@ class BaseART(BaseEstimator, ClusterMixin):
         self.weight_sample_counter_[idx] += 1
         self.W[idx] = new_w
 
+    def _match_tracking(self, cache: dict, epsilon: float, params: dict, method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"]) -> bool:
+        M = cache["match_criterion"]
+        if method == "MT+":
+            self.params["rho"] = M+epsilon
+            return True
+        elif method == "MT-":
+            self.params["rho"] = M - epsilon
+            return True
+        elif method == "MT0":
+            self.params["rho"] = M
+            return True
+        elif method == "MT1":
+            self.params["rho"] = np.inf
+            return False
+        elif method == "MT~":
+            return True
+        else:
+            raise ValueError(f"Invalid Match Tracking Method: {method}")
 
-    def _step_fit_original(self, x: np.ndarray, match_reset_func: Optional[Callable] = None) -> int:
+    @staticmethod
+    def _match_tracking_operator(method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"]) -> Callable:
+        if method in ["MT+", "MT-","MT1"]:
+            return operator.ge
+        elif method in ["MT0", "MT~"]:
+            return operator.gt
+        else:
+            raise ValueError(f"Invalid Match Tracking Method: {method}")
+
+    def _set_params(self, new_params):
+        self.params = new_params
+
+    def _deep_copy_params(self) -> dict:
+        return deepcopy(self.params)
+
+
+    def step_fit(self, x: np.ndarray, match_reset_func: Optional[Callable] = None, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0) -> int:
         """
         fit the model to a single sample
 
@@ -284,13 +319,21 @@ class BaseART(BaseEstimator, ClusterMixin):
         - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
             Permits external factors to influence cluster creation.
             Returns True if the cluster is valid for the sample, False otherwise
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
+
 
         Returns:
             cluster label of the input sample
 
         """
         self.sample_counter_ += 1
-        base_params = deepcopy(self.params)
+        base_params = self._deep_copy_params()
+        mt_operator = self._match_tracking_operator(match_reset_method)
         if len(self.W) == 0:
             w_new = self.new_weight(x, self.params)
             self.add_weight(w_new)
@@ -302,87 +345,27 @@ class BaseART(BaseEstimator, ClusterMixin):
                 c_ = int(np.nanargmax(T))
                 w = self.W[c_]
                 cache = T_cache[c_]
-                m, cache = self.match_criterion_bin(x, w, params=self.params, cache=cache)
+                m, cache = self.match_criterion_bin(x, w, params=self.params, cache=cache, op=mt_operator)
                 no_match_reset = (
                         match_reset_func is None or
                         match_reset_func(x, w, c_, params=self.params, cache=cache)
                 )
                 if m and no_match_reset:
                     self.set_weight(c_, self.update(x, w, self.params, cache=cache))
-                    self.params = base_params
+                    self._set_params(base_params)
                     return c_
                 else:
                     T[c_] = np.nan
                     if not no_match_reset:
-                        self.params["rho"] = cache["match_criterion"]
+                        keep_searching = self._match_tracking(cache, epsilon, self.params, match_reset_method)
+                        if not keep_searching:
+                            T[:] = np.nan
 
             c_new = len(self.W)
             w_new = self.new_weight(x, self.params)
             self.add_weight(w_new)
-            self.params = base_params
+            self._set_params(base_params)
             return c_new
-
-    def _step_fit_modified(self, x: np.ndarray, match_reset_func: Optional[Callable] = None) -> int:
-        """
-        fit the model to a single sample using the modified match reset method
-
-        Parameters:
-        - x: data sample
-        - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
-            Permits external factors to influence cluster creation.
-            Returns True if the cluster is valid for the sample, False otherwise
-
-        Returns:
-            cluster label of the input sample
-
-        """
-        self.sample_counter_ += 1
-        if len(self.W) == 0:
-            w_new = self.new_weight(x, self.params)
-            self.add_weight(w_new)
-            return 0
-        else:
-            T_values, T_cache = zip(*[self.category_choice(x, w, params=self.params) for w in self.W])
-            T = np.array(T_values)
-            while any(~np.isnan(T)):
-                c_ = int(np.nanargmax(T))
-                w = self.W[c_]
-                cache = T_cache[c_]
-                m, cache = self.match_criterion_bin(x, w, params=self.params, cache=cache)
-                no_match_reset = (
-                        match_reset_func is None or
-                        match_reset_func(x, w, c_, params=self.params, cache=cache)
-                )
-                if m and no_match_reset:
-                    self.set_weight(c_, self.update(x, w, self.params, cache=cache))
-                    return c_
-                else:
-                    T[c_] = np.nan
-
-            c_new = len(self.W)
-            w_new = self.new_weight(x, self.params)
-            self.add_weight(w_new)
-            return c_new
-
-    def step_fit(self, x: np.ndarray, match_reset_func: Optional[Callable] = None, match_reset_method: Literal["original", "modified"] = "original") -> int:
-        """
-        fit the model to a single sample
-
-        Parameters:
-        - x: data sample
-        - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
-            Permits external factors to influence cluster creation.
-            Returns True if the cluster is valid for the sample, False otherwise
-        - match_reset_method: either "original" or "modified"
-
-        Returns:
-            cluster label of the input sample
-
-        """
-        if match_reset_method == "original":
-            return self._step_fit_original(x, match_reset_func)
-        else:
-            return self._step_fit_modified(x, match_reset_func)
 
     def step_pred(self, x) -> int:
         """
@@ -435,7 +418,7 @@ class BaseART(BaseEstimator, ClusterMixin):
         pass
 
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_func: Optional[Callable] = None, max_iter=1, match_reset_method: Literal["original", "modified"] = "original"):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_func: Optional[Callable] = None, max_iter=1, match_reset_method:Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
         """
         Fit the model to the data
 
@@ -458,14 +441,14 @@ class BaseART(BaseEstimator, ClusterMixin):
         for _ in range(max_iter):
             for i, x in enumerate(X):
                 self.pre_step_fit(X)
-                c = self.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method)
+                c = self.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method, epsilon=epsilon)
                 self.labels_[i] = c
                 self.post_step_fit(X)
         self.post_fit(X)
         return self
 
 
-    def partial_fit(self, X: np.ndarray, match_reset_func: Optional[Callable] = None, match_reset_method: Literal["original", "modified"] = "original"):
+    def partial_fit(self, X: np.ndarray, match_reset_func: Optional[Callable] = None, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
         """
         iteratively fit the model to the data
 
@@ -490,7 +473,7 @@ class BaseART(BaseEstimator, ClusterMixin):
             j = len(self.labels_)
             self.labels_ = np.pad(self.labels_, [(0, X.shape[0])], mode='constant')
         for i, x in enumerate(X):
-            c = self.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method)
+            c = self.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method, epsilon=epsilon)
             self.labels_[i+j] = c
         return self
 

--- a/artlib/common/BaseARTMAP.py
+++ b/artlib/common/BaseARTMAP.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Union, Optional, Iterable
+from typing import Union, Optional, Iterable, Literal
 from collections import defaultdict
 from matplotlib.axes import Axes
 from sklearn.base import BaseEstimator, ClassifierMixin, ClusterMixin
@@ -75,7 +75,7 @@ class BaseARTMAP(BaseEstimator, ClassifierMixin, ClusterMixin):
         """
         raise NotImplementedError
 
-    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1):
+    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Fit the model to the data
 
@@ -87,7 +87,7 @@ class BaseARTMAP(BaseEstimator, ClassifierMixin, ClusterMixin):
         """
         raise NotImplementedError
 
-    def partial_fit(self, X: np.ndarray, y: np.ndarray):
+    def partial_fit(self, X: np.ndarray, y: np.ndarray, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Partial fit the model to the data
 

--- a/artlib/cvi/CVIART.py
+++ b/artlib/cvi/CVIART.py
@@ -149,7 +149,12 @@ class CVIART(BaseART):
             Permits external factors to influence cluster creation.
             Returns True if the cluster is valid for the sample, False otherwise
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         self.data = X

--- a/artlib/cvi/CVIART.py
+++ b/artlib/cvi/CVIART.py
@@ -1,4 +1,5 @@
 import numpy as np
+from copy import deepcopy
 import sklearn.metrics as metrics
 from typing import Optional, List, Callable, Literal, Iterable
 from matplotlib.axes import Axes
@@ -111,9 +112,46 @@ class CVIART(BaseART):
             return new_VI > old_VI
         else:
             return new_VI < old_VI
+    def _match_tracking(self, cache: dict, epsilon: float, params: dict, method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"]) -> bool:
+        M = cache["match_criterion"]
+        if method == "MT+":
+            self.base_module.params["rho"] = M+epsilon
+            return True
+        elif method == "MT-":
+            self.base_module.params["rho"] = M - epsilon
+            return True
+        elif method == "MT0":
+            self.base_module.params["rho"] = M
+            return True
+        elif method == "MT1":
+            self.base_module.params["rho"] = np.inf
+            return False
+        elif method == "MT~":
+            return True
+        else:
+            raise ValueError(f"Invalid Match Tracking Method: {method}")
+
+    def _set_params(self, new_params):
+        self.base_module.params = new_params
+
+    def _deep_copy_params(self) -> dict:
+        return deepcopy(self.base_module.params)
 
     def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_func: Optional[Callable] = None,
-            max_iter=1, match_reset_method: Literal["original", "modified"] = "original"):
+            max_iter=1, match_reset_method:Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
+        """
+        Fit the model to the data
+
+        Parameters:
+        - X: data set
+        - y: not used. For compatibility.
+        - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
+            Permits external factors to influence cluster creation.
+            Returns True if the cluster is valid for the sample, False otherwise
+        - max_iter: number of iterations to fit the model on the same data set
+        - match_reset_method: either "original" or "modified"
+
+        """
         self.data = X
         self.base_module.validate_data(X)
         self.base_module.check_dimensions(X)
@@ -128,7 +166,7 @@ class CVIART(BaseART):
                     cvi_match_reset_func = lambda i, w, cluster_a, params, cache: self.CVI_match(i, w, cluster_a, params, {"index": index, "validity":self.params["validity"]}, cache)
                 else:
                     cvi_match_reset_func = lambda i, w, cluster_a, params, cache: (match_reset_func(i,w,cluster_a,params,cache) and self.CVI_match(i, w, cluster_a, params, {"index": index, "validity":self.params["validity"]}, cache))
-                c = self.base_module.step_fit(x, match_reset_func=cvi_match_reset_func, match_reset_method=match_reset_method)
+                c = self.base_module.step_fit(x, match_reset_func=cvi_match_reset_func, match_reset_method=match_reset_method, epsilon=epsilon)
                 self.labels_[index] = c
                 self.post_step_fit(X)
 
@@ -139,8 +177,27 @@ class CVIART(BaseART):
     def post_step_fit(self, X: np.ndarray):
         return self.base_module.post_step_fit(X)
 
-    def step_fit(self, x: np.ndarray, match_reset_func: Optional[Callable] = None,
-                 match_reset_method: Literal["original", "modified"] = "original") -> int:
+    def step_fit(self, x: np.ndarray, match_reset_func: Optional[Callable] = None, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0) -> int:
+        """
+        fit the model to a single sample
+
+        Parameters:
+        - x: data sample
+        - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
+            Permits external factors to influence cluster creation.
+            Returns True if the cluster is valid for the sample, False otherwise
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
+
+
+        Returns:
+            cluster label of the input sample
+
+        """
         raise NotImplementedError
 
     def step_pred(self, x) -> int:

--- a/artlib/cvi/iCVIFuzzyArt.py
+++ b/artlib/cvi/iCVIFuzzyArt.py
@@ -53,7 +53,12 @@ class iCVIFuzzyART(FuzzyART):
             Permits external factors to influence cluster creation.
             Returns True if the cluster is valid for the sample, False otherwise
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         self.validate_data(X)
@@ -74,10 +79,10 @@ class iCVIFuzzyART(FuzzyART):
             self.pre_step_fit(X)
             self.index = i
             if match_reset_func is None:
-                c = self.step_fit(x, match_reset_func=self.iCVI_match)
+                c = self.step_fit(x, match_reset_func=self.iCVI_match, match_reset_method=match_reset_method, epsilon=epsilon)
             else:
                 match_reset_func = lambda x, w, c_, params, cache: (match_reset_func(x, w, c_, params, cache) & self.iCVI_match(x, w, c_, params, cache))
-                c = self.step_fit(x, match_reset_func=match_reset_func)
+                c = self.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method, epsilon=epsilon)
 
             if self.offline:
                 params = self.iCVI.switch_label(x, self.labels_[i], c)

--- a/artlib/cvi/iCVIFuzzyArt.py
+++ b/artlib/cvi/iCVIFuzzyArt.py
@@ -7,6 +7,7 @@ Extended icvi offline mode can be found at
 https://ieeexplore.ieee.org/document/9745260
 """
 import numpy as np
+from typing import Optional, Literal, Callable
 from artlib.elementary.FuzzyART import FuzzyART
 from artlib.cvi.iCVIs.CalinkskiHarabasz import iCVI_CH
 
@@ -41,7 +42,20 @@ class iCVIFuzzyART(FuzzyART):
         # return self.iCVI.evalLabel(x, c_) This except pass params instead.
 
     # Could add max epochs back in, but only if offline is true, or do something special...
-    def fit(self, X: np.ndarray):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_func: Optional[Callable] = None, max_iter=1, match_reset_method:Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
+        """
+        Fit the model to the data
+
+        Parameters:
+        - X: data set
+        - y: not used. For compatibility.
+        - match_reset_func: a callable accepting the data sample, a cluster weight, the params dict, and the cache dict
+            Permits external factors to influence cluster creation.
+            Returns True if the cluster is valid for the sample, False otherwise
+        - max_iter: number of iterations to fit the model on the same data set
+        - match_reset_method: either "original" or "modified"
+
+        """
         self.validate_data(X)
         self.check_dimensions(X)
         self.is_fitted_ = True
@@ -59,7 +73,11 @@ class iCVIFuzzyART(FuzzyART):
         for i, x in enumerate(X):
             self.pre_step_fit(X)
             self.index = i
-            c = self.step_fit(x, match_reset_func=self.iCVI_match)
+            if match_reset_func is None:
+                c = self.step_fit(x, match_reset_func=self.iCVI_match)
+            else:
+                match_reset_func = lambda x, w, c_, params, cache: (match_reset_func(x, w, c_, params, cache) & self.iCVI_match(x, w, c_, params, cache))
+                c = self.step_fit(x, match_reset_func=match_reset_func)
 
             if self.offline:
                 params = self.iCVI.switch_label(x, self.labels_[i], c)

--- a/artlib/experimental/SeqART.py
+++ b/artlib/experimental/SeqART.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Optional, Callable
 from artlib import BaseART
-from artlib.common.utils import normalize
+import operator
 import re
 
 def compress_dashes(input_string):
@@ -159,7 +159,7 @@ class SeqART(BaseART):
 
         return cache['score'], cache
 
-    def match_criterion_bin(self, i: str, w: str, params: dict, cache: Optional[dict] = None) -> tuple[bool, dict]:
+    def match_criterion_bin(self, i: np.ndarray, w: np.ndarray, params: dict, cache: Optional[dict] = None, op: Callable = operator.ge) -> tuple[bool, dict]:
         """
         get the binary match criterion of the cluster
 
@@ -174,7 +174,13 @@ class SeqART(BaseART):
 
         """
         M, cache = self.match_criterion(arr2seq(i), w, params, cache)
-        return M > params['rho'], cache
+        M_bin = op(M, params["rho"])
+        if cache is None:
+            cache = dict()
+        cache["match_criterion"] = M
+        cache["match_criterion_bin"] = M_bin
+
+        return M_bin, cache
 
     def update(self, i: str, w: str, params: dict, cache: Optional[dict] = None) -> str:
         """

--- a/artlib/hierarchical/SMART.py
+++ b/artlib/hierarchical/SMART.py
@@ -58,7 +58,7 @@ class SMART(DeepARTMAP):
         X_, _ = super(SMART, self).restore_data([X] * self.n_modules)
         return X_[0]
 
-    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, max_iter=1, match_reset_method: Literal["original", "modified"] = "original"):
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, max_iter=1, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
         """
         Fit the model to the data
 
@@ -66,15 +66,20 @@ class SMART(DeepARTMAP):
         - X: data set A
         - y: not used
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         X_list = [X]*self.n_modules
-        return super().fit(X_list, max_iter=max_iter, match_reset_method=match_reset_method)
+        return super().fit(X_list, max_iter=max_iter, match_reset_method=match_reset_method, epsilon=epsilon)
 
-    def partial_fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_method: Literal["original", "modified"] = "original"):
+    def partial_fit(self, X: np.ndarray, y: Optional[np.ndarray] = None, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 0.0):
         X_list = [X] * self.n_modules
-        return self.partial_fit(X_list, match_reset_method=match_reset_method)
+        return self.partial_fit(X_list, match_reset_method=match_reset_method, epsilon=epsilon)
 
     def plot_cluster_bounds(self, ax: Axes, colors: Iterable, linewidth: int = 1):
         """

--- a/artlib/supervised/ARTMAP.py
+++ b/artlib/supervised/ARTMAP.py
@@ -94,7 +94,7 @@ class ARTMAP(SimpleARTMAP):
         """
         return self.module_a.restore_data(X), self.module_b.restore_data(y)
 
-    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1, match_reset_method: Literal["original", "modified"] = "original"):
+    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Fit the model to the data
 
@@ -108,16 +108,16 @@ class ARTMAP(SimpleARTMAP):
         # Check that X and y have correct shape
         self.validate_data(X, y)
 
-        self.module_b.fit(y, max_iter=max_iter, match_reset_method=match_reset_method)
+        self.module_b.fit(y, max_iter=max_iter, match_reset_method=match_reset_method, epsilon=epsilon)
 
         y_c = self.module_b.labels_
 
-        super(ARTMAP, self).fit(X, y_c, max_iter=max_iter, match_reset_method=match_reset_method)
+        super(ARTMAP, self).fit(X, y_c, max_iter=max_iter, match_reset_method=match_reset_method, epsilon=epsilon)
 
         return self
 
 
-    def partial_fit(self, X: np.ndarray, y: np.ndarray, match_reset_method: Literal["original", "modified"] = "original"):
+    def partial_fit(self, X: np.ndarray, y: np.ndarray, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Partial fit the model to the data
 
@@ -128,8 +128,8 @@ class ARTMAP(SimpleARTMAP):
 
         """
         self.validate_data(X, y)
-        self.module_b.partial_fit(y, match_reset_method=match_reset_method)
-        super(ARTMAP, self).partial_fit(X, self.labels_b, match_reset_method=match_reset_method)
+        self.module_b.partial_fit(y, match_reset_method=match_reset_method, epsilon=epsilon)
+        super(ARTMAP, self).partial_fit(X, self.labels_b, match_reset_method=match_reset_method, epsilon=epsilon)
         return self
 
 

--- a/artlib/supervised/ARTMAP.py
+++ b/artlib/supervised/ARTMAP.py
@@ -102,7 +102,12 @@ class ARTMAP(SimpleARTMAP):
         - X: data set A
         - y: data set B
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         # Check that X and y have correct shape
@@ -124,7 +129,12 @@ class ARTMAP(SimpleARTMAP):
         Parameters:
         - X: data set A
         - y: data set B
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         self.validate_data(X, y)

--- a/artlib/supervised/SimpleARTMAP.py
+++ b/artlib/supervised/SimpleARTMAP.py
@@ -108,7 +108,12 @@ class SimpleARTMAP(BaseARTMAP):
         Parameters:
         - x: data sample for side A
         - c_b: side b label
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         Returns:
             side A cluster label
@@ -132,7 +137,12 @@ class SimpleARTMAP(BaseARTMAP):
         - X: data set A
         - y: data set B
         - max_iter: number of iterations to fit the model on the same data set
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         # Check that X and y have correct shape
@@ -159,7 +169,12 @@ class SimpleARTMAP(BaseARTMAP):
         Parameters:
         - X: data set A
         - y: data set B
-        - match_reset_method: either "original" or "modified"
+        - match_reset_method:
+            "MT+": Original method, rho=M+epsilon
+             "MT-": rho=M-epsilon
+             "MT0": rho=M, using > operator
+             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
+             "MT~": do not change rho
 
         """
         SimpleARTMAP.validate_data(self, X, y)

--- a/artlib/supervised/SimpleARTMAP.py
+++ b/artlib/supervised/SimpleARTMAP.py
@@ -101,7 +101,7 @@ class SimpleARTMAP(BaseARTMAP):
         """
         return self.module_a.restore_data(X)
 
-    def step_fit(self, x: np.ndarray, c_b: int, match_reset_method: Literal["original", "modified"] = "original") -> int:
+    def step_fit(self, x: np.ndarray, c_b: int, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10) -> int:
         """
         Fit the model to a single sample
 
@@ -117,14 +117,14 @@ class SimpleARTMAP(BaseARTMAP):
         match_reset_func = lambda i, w, cluster, params, cache: self.match_reset_func(
             i, w, cluster, params=params, extra={"cluster_b": c_b}, cache=cache
         )
-        c_a = self.module_a.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method)
+        c_a = self.module_a.step_fit(x, match_reset_func=match_reset_func, match_reset_method=match_reset_method, epsilon=epsilon)
         if c_a not in self.map:
             self.map[c_a] = c_b
         else:
             assert self.map[c_a] == c_b
         return c_a
 
-    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1, match_reset_method: Literal["original", "modified"] = "original"):
+    def fit(self, X: np.ndarray, y: np.ndarray, max_iter=1, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Fit the model to the data
 
@@ -147,12 +147,12 @@ class SimpleARTMAP(BaseARTMAP):
         for _ in range(max_iter):
             for i, (x, c_b) in enumerate(zip(X, y)):
                 self.module_a.pre_step_fit(X)
-                c_a = self.step_fit(x, c_b, match_reset_method=match_reset_method)
+                c_a = self.step_fit(x, c_b, match_reset_method=match_reset_method, epsilon=epsilon)
                 self.module_a.labels_[i] = c_a
                 self.module_a.post_step_fit(X)
         return self
 
-    def partial_fit(self, X: np.ndarray, y: np.ndarray, match_reset_method: Literal["original", "modified"] = "original"):
+    def partial_fit(self, X: np.ndarray, y: np.ndarray, match_reset_method: Literal["MT+", "MT-", "MT0", "MT1", "MT~"] = "MT+", epsilon: float = 1e-10):
         """
         Partial fit the model to the data
 
@@ -175,7 +175,7 @@ class SimpleARTMAP(BaseARTMAP):
             self.module_a.labels_ = np.pad(self.module_a.labels_, [(0, X.shape[0])], mode='constant')
         for i, (x, c_b) in enumerate(zip(X, y)):
             self.module_a.pre_step_fit(X)
-            c_a = self.step_fit(x, c_b, match_reset_method=match_reset_method)
+            c_a = self.step_fit(x, c_b, match_reset_method=match_reset_method, epsilon=epsilon)
             self.module_a.labels_[i+j] = c_a
             self.module_a.post_step_fit(X)
         return self

--- a/artlib/topological/TopoART.py
+++ b/artlib/topological/TopoART.py
@@ -323,12 +323,11 @@ class TopoART(BaseART):
                         if not keep_searching:
                             T[:] = np.nan
 
-            self.base_module.params = base_params
+            self._set_params(base_params)
             if resonant_c < 0:
                 c_new = len(self.W)
                 w_new = self.new_weight(x, self.params)
                 self.add_weight(w_new)
-                self._set_params(base_params)
                 return c_new
 
             return resonant_c


### PR DESCRIPTION
        - match_reset_method:
            "MT+": Original method, rho=M+epsilon
             "MT-": rho=M-epsilon
             "MT0": rho=M, using > operator
             "MT1": rho=1.0,  Immediately create a new cluster on mismatch
             "MT~": do not change rho